### PR TITLE
DM-40296: Add a timestamp to FannedOutVisit

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ class NextVisitModel:
     nimages: int
     survey: str
     totalCheckpoints: int
+    private_sndStamp: float
 
     def add_detectors(
         self,
@@ -276,6 +277,9 @@ async def main() -> None:
                         survey=next_visit_message_initial["message"]["survey"],
                         totalCheckpoints=next_visit_message_initial["message"][
                             "totalCheckpoints"
+                        ],
+                        private_sndStamp=next_visit_message_initial["message"][
+                            "private_sndStamp"
                         ],
                     )
 


### PR DESCRIPTION
This PR modifies the fan-out service to include a timestamp in outgoing visits. This is a breaking change to the visit message format, and must be merged alongside lsst-dm/prompt_prototype#79.