### PR TITLE
DM-43180: Filter out old messages in fan-out service

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,26 @@
+import asyncio
+import dataclasses
 import json
 import logging
 import os
+from pathlib import Path
 import sys
-import asyncio
-import httpx
-import yaml
 import typing
-import dataclasses
+
 from aiokafka import AIOKafkaConsumer  # type:ignore
 from cloudevents.conversion import to_structured
 from cloudevents.http import CloudEvent
-from dataclasses import dataclass
-from pathlib import Path
-from kafkit.registry.httpx import RegistryApi
+import httpx
 from kafkit.registry import Deserializer
+from kafkit.registry.httpx import RegistryApi
 from prometheus_client import start_http_server, Summary  # type:ignore
 from prometheus_client import Gauge
+import yaml
 
 REQUEST_TIME = Summary("request_processing_seconds", "Time spent processing request")
 
 
-@dataclass
+@dataclasses.dataclass
 class NextVisitModel:
     "Next Visit Message"
     salIndex: int


### PR DESCRIPTION
This PR adds a timestamp-based filter that rejects old messages instead of forwarding them to Prompt Processing. Ignoring old messages makes Prompt Processing more robust against network problems that cause large volumes of messages to be delivered at once.

The filter is configured by a mandatory envvar, `MESSAGE_EXPIRATION`, giving the maximum age in seconds.