### PR TITLE
DM-45258: Clarify text in next_visit_fan_out logs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -281,7 +281,7 @@ async def main() -> None:
                         published = next_visit_message_initial["message"]["private_efdStamp"]
                         age = time.time() - published
                         if age > expire:
-                            logging.warning("Message published at %s is %s old, ignoring.",
+                            logging.warning("Message published on %s UTC is %s old, ignoring.",
                                             time.ctime(published),
                                             datetime.timedelta(seconds=age)
                                             )

--- a/src/main.py
+++ b/src/main.py
@@ -279,7 +279,7 @@ async def main() -> None:
                     # efdStamp is visit publication, in seconds since 1970-01-01 UTC
                     if next_visit_message_initial["message"]["private_efdStamp"]:
                         published = next_visit_message_initial["message"]["private_efdStamp"]
-                        age = time.time() - published
+                        age = round(time.time() - published)  # Microsecond precision is distracting
                         if age > expire:
                             logging.warning("Message published on %s UTC is %s old, ignoring.",
                                             time.ctime(published),


### PR DESCRIPTION
This PR makes the logs associated with old messages slightly more human-friendly by providing an explicit timezone and reporting message age only to the nearest second.