### PR TITLE
DM-43082: Knative Time Header

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -352,9 +352,11 @@ def dispatch_fanned_out_messages(client: httpx.AsyncClient,
         Whether or not Knative requests can be retried.
     """
     try:
+
         attributes = {
             "type": "com.example.kafka",
             "source": topic,
+            "time": str(time.time())
         }
 
         for fan_out_message in send_info.fan_out_messages:


### PR DESCRIPTION
Adds time to knative header.  Used to track time it takes from when fan out message sent to when it is loaded in prompt processing.