### PR TITLE
DM-49290: Kafka Consumer Offset and Timestamp Logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -530,6 +530,7 @@ async def main() -> None:
                         next_visit_message_initial = await deserializer.deserialize(
                             data=msg.value
                         )
+                        logging.info(f"message offset {msg.offset} and timestamp {msg.timestamp}")
                         logging.info(f"message deserialized {next_visit_message_initial}")
                         if not is_handleable(next_visit_message_initial["message"], expire):
                             continue


### PR DESCRIPTION
Add logging of fan out message offset and timestamp.  This will help with investigating ghost messages.