### PR TITLE
DM-50267

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import ssl
 import sys
 import time
 import typing
@@ -569,6 +570,11 @@ async def main() -> None:
     # Start Prometheus endpoint
     start_http_server(8000)
 
+    # Create ssl context for Kafka consumer
+    ssl_context = context = ssl.create_default_context()
+    ssl_context.check_hostname = False # TODO set to true when migrated to prompt-kafka
+    ssl_context.verify_mode=ssl.CERT_NONE # TODO enable when migrated to prompt-kafka
+
     consumer = AIOKafkaConsumer(
         topic,
         bootstrap_servers=kafka_cluster,
@@ -578,6 +584,7 @@ async def main() -> None:
         sasl_mechanism=sasl_mechanism,
         sasl_plain_username=sasl_username,
         sasl_plain_password=sasl_password,
+        ssl_context=ssl_context,
     )
 
     gauges = {inst: Metrics(inst) for inst in supported_instruments}


### PR DESCRIPTION
Add ssl context to Kafka consumer for Sasquatch change from SASL_PLAIN to SASL_SSL.  A self signed certificates is currently on Sasquatch and no DNS entry so certificate and hostname validation is disabled. 

This change is needed because Sasquatch changed to SSL on the external bootstrap listener.   When DM-49215 is implemented SSL and hostname validation will be enabled.